### PR TITLE
Update interface version

### DIFF
--- a/TurtleSnacks.toc
+++ b/TurtleSnacks.toc
@@ -1,4 +1,4 @@
-## Interface: 12000
+## Interface: 11200
 ## Title: TurtleSnacks
 ## Notes: scruunch scruunch, it'll nibble your buttons.
 ## Author: McPewPew


### PR DESCRIPTION
With this change won't have to "load out of date addons"

`11200` is same used in:
* [Sortbags](https://github.com/shirsig/SortBags-vanilla/blob/117ec33a6d1a2d565c40aeeda0fdf639d5fb8aa2/SortBags.toc#L1)
* [pfUI](https://github.com/shagu/pfUI/blob/3894a99a658329c23fbf0ff2c13597fb22ba92cc/pfUI.toc#L1)
* [pfQuest-turtle](https://github.com/shagu/pfQuest-turtle/blob/cd72d006ef2d39f97617b5853fd46d51c954db19/pfQuest-turtle.toc#L1)
...

So seemed correct to add for a turtlewow focused addon